### PR TITLE
More accurate reporting for recursive property not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 .classpath
 .project
 .config/
+.idea/
+*.iml

--- a/dollarbrace/src/main/java/org/atteo/dollarbrace/CompoundPropertyResolver.java
+++ b/dollarbrace/src/main/java/org/atteo/dollarbrace/CompoundPropertyResolver.java
@@ -56,24 +56,26 @@ public class CompoundPropertyResolver implements PropertyResolver {
 	public String resolveProperty(String name, PropertyFilter recurse) throws PropertyNotFoundException {
 		for (Entry<String, Collection<PrefixedPropertyResolver>> entry : prefixedResolvers.asMap().entrySet()) {
 			if (name.startsWith(entry.getKey())) {
+				PropertyNotFoundException lastException = null;
 				for (PrefixedPropertyResolver resolver : entry.getValue()) {
 					try {
 						return resolver.resolveProperty(name, recurse);
 					} catch (PropertyNotFoundException e) {
-						// ok, try next one
+						lastException = e;
 					}
 				}
-				throw new PropertyNotFoundException(name);
+				throw new PropertyNotFoundException(name, lastException);
 			}
 		}
 
+		PropertyNotFoundException lastException = null;
 		for (PropertyResolver resolver : resolvers) {
 			try {
 				return resolver.resolveProperty(name, recurse);
 			} catch (PropertyNotFoundException e) {
-				// ok, try next one
+				lastException = e;
 			}
 		}
-		throw new PropertyNotFoundException(name);
+		throw new PropertyNotFoundException(name, lastException);
 	}
 }

--- a/dollarbrace/src/main/java/org/atteo/dollarbrace/PropertyNotFoundException.java
+++ b/dollarbrace/src/main/java/org/atteo/dollarbrace/PropertyNotFoundException.java
@@ -18,11 +18,49 @@ package org.atteo.dollarbrace;
  */
 @SuppressWarnings("serial")
 public class PropertyNotFoundException extends Exception {
+
+	private final String propertyName;
+
 	public PropertyNotFoundException(String propertyName) {
-		super("Property not found: '" + propertyName + "'");
+		super();
+		this.propertyName = propertyName;
 	}
 
 	public PropertyNotFoundException(String propertyName, Throwable cause) {
-		super("Property not found: '" + propertyName + "': " + cause.getMessage(), cause);
+		super(cause);
+		this.propertyName = propertyName;
+	}
+
+	public PropertyNotFoundException(String propertyName, PropertyNotFoundException cause) {
+		super();
+		this.propertyName = propertyName;
+		if ( cause != null && !propertyName.equals(cause.propertyName)) {
+			initCause(cause);
+		}
+	}
+
+	@Override
+	public String getMessage() {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("'").append(propertyName).append("'");
+
+		Throwable couse = getCause();
+		String lastProperty = null;
+
+		while (couse != null) {
+			if (couse instanceof PropertyNotFoundException) {
+				lastProperty =((PropertyNotFoundException) couse).propertyName;
+				sb.append(" -> '").append(lastProperty).append("'");
+			}
+			couse = couse.getCause();
+		}
+		if (lastProperty == null) {
+			sb.insert(0, "Property not found: ");
+		} else {
+			sb.insert(0, "Property not found: '" + lastProperty + "' [");
+			sb.append("]");
+		}
+		return sb.toString();
 	}
 }

--- a/dollarbrace/src/main/java/org/atteo/dollarbrace/PropertyNotFoundException.java
+++ b/dollarbrace/src/main/java/org/atteo/dollarbrace/PropertyNotFoundException.java
@@ -45,15 +45,15 @@ public class PropertyNotFoundException extends Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("'").append(propertyName).append("'");
 
-		Throwable couse = getCause();
+		Throwable cause = getCause();
 		String lastProperty = null;
 
-		while (couse != null) {
-			if (couse instanceof PropertyNotFoundException) {
-				lastProperty =((PropertyNotFoundException) couse).propertyName;
+		while (cause != null) {
+			if (cause instanceof PropertyNotFoundException) {
+				lastProperty =((PropertyNotFoundException) cause).propertyName;
 				sb.append(" -> '").append(lastProperty).append("'");
 			}
-			couse = couse.getCause();
+			cause = cause.getCause();
 		}
 		if (lastProperty == null) {
 			sb.insert(0, "Property not found: ");

--- a/dollarbrace/src/test/java/org/atteo/dollarbrace/PropertyFilterTest.java
+++ b/dollarbrace/src/test/java/org/atteo/dollarbrace/PropertyFilterTest.java
@@ -41,11 +41,18 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 public class PropertyFilterTest {
+
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
+
 	@Test
 	public void system() throws PropertyNotFoundException {
 		// given
@@ -195,6 +202,24 @@ public class PropertyFilterTest {
 
 		// then
 		filter.getProperty("a");
+	}
+
+	@Test
+	public void recursivePropertyNotFoundReport() throws PropertyNotFoundException {
+		// given
+		expectedEx.expect(PropertyNotFoundException.class);
+		expectedEx.expectMessage("Property not found: 'third' ['first' -> 'second' -> 'third']");
+
+		Properties properties = new Properties();
+
+		properties.setProperty("first", "${second}");
+		properties.setProperty("second", "${third}");
+
+		CompoundPropertyResolver resolver = new CompoundPropertyResolver();
+		resolver.addPropertyResolver(new PropertiesPropertyResolver(properties));
+
+		// when
+		DollarBrace.getFilter(resolver).filter("${first}");
 	}
 
 	@Test


### PR DESCRIPTION
When we use recursive property PropertyNotFoundException should tell us which property is not defined.
